### PR TITLE
respect trs_status currentSleepTime, fix spawn log

### DIFF
--- a/monitoring
+++ b/monitoring
@@ -34,10 +34,13 @@ function check_tr () {
 function check_devices () {
      echo "$(date +'%F %T') | Checking device status..."
      while read -r device; do
-         lastData=$(export MYSQL_PWD="${SCANNER_PASSWORD}"; mysql -h "${SCANNER_HOST}" -u "${SCANNER_USER}" -D "${SCANNER_DATABASE}" -N -B -e 'SELECT UNIX_TIMESTAMP(lastProtoDateTime) FROM trs_status WHERE device_id="'"$device"'"')
+         timestamps=$(export MYSQL_PWD="${SCANNER_PASSWORD}"; mysql -h "${SCANNER_HOST}" -u "${SCANNER_USER}" -D "${SCANNER_DATABASE}" -N -B -e 'SELECT UNIX_TIMESTAMP(lastProtoDateTime), currentSleepTime FROM trs_status WHERE device_id="'"$device"'"')
         devicename=$(export MYSQL_PWD="${SCANNER_PASSWORD}"; mysql -h "${SCANNER_HOST}" -u "${SCANNER_USER}" -D "${SCANNER_DATABASE}" -N -B -e 'SELECT name FROM settings_device WHERE device_id="'"$device"'"')
 	 now=$(date '+%s')
-         if [[ $lastData -lt $((now-${STATUS_DOWN})) ]]; then
+     array=($(for i in $timestamps; do echo $i; done))
+     lastData=${array[0]}
+     sleepTime=${array[1]}
+         if [[ $lastData -lt $((now-${STATUS_DOWN}-$sleepTime)) ]]; then
              currentStatus="0"
 	     echo "$(date +'%F %T') | Device $devicename offline"
          else
@@ -57,7 +60,7 @@ function check_raids () {
 
 function check_spawnpoints () {
     spawnpoints=$(export MYSQL_PWD="${SCANNER_PASSWORD}"; mysql -h "${SCANNER_HOST}" -u "${SCANNER_USER}" -D "${SCANNER_DATABASE}" -N -B -e "select count(*) from trs_spawn where calc_endminsec is null and first_detection > DATE_SUB(now(), INTERVAL 24 HOUR);")
-    echo "$(date +'%F %T') | Unknown Spanwpoints in the last 24h: $quests"
+    echo "$(date +'%F %T') | Unknown Spanwpoints in the last 24h: $spawnpoints"
     mysql -h database -u "$GRAFANA_USER" -D "$GRAFANA_DATABASE" -N -B -e 'INSERT INTO spawnpoint_data(timestamp,value) VALUES(now(),"'"$spawnpoints"'")'
 }
 


### PR DESCRIPTION
- quest workers could be shown as offline while waiting after a teleport that requires sleepTime larger than the offline threshold
- check_spawnpoints logged the wrong variable